### PR TITLE
Widget instance id passing issue fix for use in WPML plugin

### DIFF
--- a/includes/widgets/class-flash-widget-about.php
+++ b/includes/widgets/class-flash-widget-about.php
@@ -73,6 +73,8 @@ class FT_Widget_About extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-about.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-blog.php
+++ b/includes/widgets/class-flash-widget-blog.php
@@ -83,6 +83,8 @@ class FT_Widget_Blog extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-blog.php', array( 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-counter.php
+++ b/includes/widgets/class-flash-widget-counter.php
@@ -88,6 +88,8 @@ class FT_Widget_Counter extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-counter.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-cta.php
+++ b/includes/widgets/class-flash-widget-cta.php
@@ -86,6 +86,8 @@ class FT_Widget_CTA extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-cta.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-heading.php
+++ b/includes/widgets/class-flash-widget-heading.php
@@ -57,6 +57,8 @@ class FT_Widget_Heading extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-heading.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-image.php
+++ b/includes/widgets/class-flash-widget-image.php
@@ -57,6 +57,8 @@ class FT_Widget_Image extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-image.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-logo.php
+++ b/includes/widgets/class-flash-widget-logo.php
@@ -88,6 +88,8 @@ class FT_Widget_Logo extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-logo.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-portfolio.php
+++ b/includes/widgets/class-flash-widget-portfolio.php
@@ -104,6 +104,8 @@ class FT_Widget_Portfolio extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-portfolio.php', array( 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-service.php
+++ b/includes/widgets/class-flash-widget-service.php
@@ -99,6 +99,8 @@ class FT_Widget_Service extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-service.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-slider.php
+++ b/includes/widgets/class-flash-widget-slider.php
@@ -133,6 +133,8 @@ class FT_Widget_Slider extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-slider.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-team.php
+++ b/includes/widgets/class-flash-widget-team.php
@@ -92,6 +92,8 @@ class FT_Widget_Team extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-team.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );

--- a/includes/widgets/class-flash-widget-testimonial.php
+++ b/includes/widgets/class-flash-widget-testimonial.php
@@ -96,6 +96,8 @@ class FT_Widget_Testimonial extends FT_Widget {
 
 		$this->widget_start( $args, $instance );
 
+		$args['widget_id'] = $this->id;
+
 		flash_get_template( 'content-widget-testimonial.php', array( 'args' => $args, 'instance' => $instance ) );
 
 		$this->widget_end( $args );


### PR DESCRIPTION
There was an issue when the page is created with the Page Builder by SiteOrigin plugin and used along with the WPML plugin, that the translated page content when viewed would not get displayed on the first view and after the refresh for same page, it would display the correct content. This commits solves this issue.