### PR TITLE
lock install routine to only allow for one execution

### DIFF
--- a/includes/class-flash-install.php
+++ b/includes/class-flash-install.php
@@ -79,6 +79,14 @@ class FT_Install {
 	 */
 	public static function install() {
 		global $wpdb;
+		
+		// Check if we are not already running this routine.
+		if ( 'yes' === get_transient( 'ft_installing' ) ) {
+			return;
+		}
+
+		// If we made it till here nothing is running yet, lets set the transient now.
+		set_transient( 'ft_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 
 		if ( ! defined( 'FT_INSTALLING' ) ) {
 			define( 'FT_INSTALLING', true );
@@ -112,6 +120,7 @@ class FT_Install {
 
 		self::update_ft_version();
 
+		delete_transient( 'ft_installing' );
 		// Flush rules after install
 		do_action( 'flash_toolkit_flush_rewrite_rules' );
 


### PR DESCRIPTION
Due to the `check_version` method running on init it can fire multiple times during a page load causing race condition when doing a new install.
This PR adds a transient lock to ensure we are only running this once.