### PR TITLE
Allow html in repeater fields

### DIFF
--- a/includes/abstracts/abstract-flash-widget.php
+++ b/includes/abstracts/abstract-flash-widget.php
@@ -196,7 +196,7 @@ abstract class FT_Widget extends WP_Widget {
 					}
 				break;
 				case 'repeater' :
-					$instance[ $key ] = isset( $new_instance[ $key ] ) ? flash_clean_html( $new_instance[ $key ] ) : '';
+					$instance[ $key ] = isset( $new_instance[ $key ] ) ? $new_instance[ $key ] : '';
 				break;
 				default:
 					$instance[ $key ] = isset( $new_instance[ $key ] ) ? flash_clean( $new_instance[ $key ] ) : '';


### PR DESCRIPTION
The widget like timeline, tab and accordion having repeatable field where text area should be html compatible. - fix