### PR TITLE
Fix warnings if $post is null

### DIFF
--- a/includes/functions-flash-core.php
+++ b/includes/functions-flash-core.php
@@ -319,6 +319,9 @@ function flash_has_manual_excerpt( $post ) {
  */
 function flashtoolkit_enqueue_script() {
 	global $post;
+	if ($post === null) {
+		return;
+	}
 	$panels_data = get_post_meta( $post->ID, 'panels_data', true );
 
 	if ( ! empty( $panels_data['widgets'] ) ) {

--- a/includes/functions-flash-core.php
+++ b/includes/functions-flash-core.php
@@ -319,7 +319,7 @@ function flash_has_manual_excerpt( $post ) {
  */
 function flashtoolkit_enqueue_script() {
 	global $post;
-	if ($post === null) {
+	if (!isset($post->ID)) {
 		return;
 	}
 	$panels_data = get_post_meta( $post->ID, 'panels_data', true );


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/attempt-to-read-property-id-on-null-in-functions-flash-core-php-on-line-322/